### PR TITLE
Fix du bug de la valeur maximale du nombre de questions d'un examen lors de sa création

### DIFF
--- a/TestGenerator.UnitTest/ExamsControllerShould.cs
+++ b/TestGenerator.UnitTest/ExamsControllerShould.cs
@@ -74,12 +74,12 @@ namespace TestGenerator.UnitTest
             var controller = new ExamsController (GetFakeContext());
 
             // Act
-            var positiveResult = controller.RetrieveQuestions(1);
+            var positiveResult = controller.RetrieveQuestions(1, 0);
 
             // Assert
             Assert.IsAssignableFrom<List<Question>>(positiveResult);
-            Assert.Throws<ArgumentException>(() => controller.RetrieveQuestions(0));
-            Assert.Throws<ArgumentException>(() => controller.RetrieveQuestions(-1));
+            Assert.Throws<ArgumentException>(() => controller.RetrieveQuestions(0, 0));
+            Assert.Throws<ArgumentException>(() => controller.RetrieveQuestions(-1, 0));
         }
 
         [Fact]

--- a/TestGenerator.Web/Controllers/ExamsController.cs
+++ b/TestGenerator.Web/Controllers/ExamsController.cs
@@ -68,7 +68,7 @@ namespace TestGenerator.Web.Controllers
                 return BadRequest(ModelState);
             }
 
-            var selectedQuestions = RetrieveQuestions(viewModel.QuestionAmount);
+            var selectedQuestions = RetrieveQuestions(viewModel.QuestionAmount, viewModel.ModuleId);
 
             var exam = new Exam
             {
@@ -112,7 +112,7 @@ namespace TestGenerator.Web.Controllers
             return View(exam);
         }
 
-        public virtual List<Question> RetrieveQuestions(int limit)
+        public virtual List<Question> RetrieveQuestions(int limit, int moduleId)
         {
             if (limit < 1)
             {
@@ -120,6 +120,7 @@ namespace TestGenerator.Web.Controllers
             }
 
             return _context.Questions
+                .Where(q => q.ModuleId.Equals(moduleId))
                 .OrderBy(r => Guid.NewGuid())
                 .Take(limit)
                 .ToList();
@@ -185,6 +186,14 @@ namespace TestGenerator.Web.Controllers
             }
 
             return View(exam);
+        }
+
+        [HttpGet]
+        public ActionResult GetModuleQuestionsAmount(int? moduleId)
+        {
+            return (moduleId != null)
+                ? Json(new { Success="true",Data = _context.Questions.Count(q => q.ModuleId.Equals(moduleId)) })
+                : Json(new { Success = "false" });
         }
     }
 }

--- a/TestGenerator.Web/Views/Exams/Create.cshtml
+++ b/TestGenerator.Web/Views/Exams/Create.cshtml
@@ -30,12 +30,14 @@
                     </div>
                     <div class="form-group">
                         <label asp-for="ModuleId" class="control-label"></label>
-                        <select id="moduleSelect" asp-for="ModuleId" asp-items="@Model.Modules" class="form-control"></select>
+                        <select id="examCreationModuleSelect" asp-for="ModuleId" asp-items="@Model.Modules" class="form-control"></select>
                         <span asp-validation-for="ModuleId" class="text-danger"></span>
                     </div>
+
                     <div class="form-group">
                         <label asp-for="QuestionAmount" class="control-label"></label>
-                        <input asp-for="QuestionAmount" min="1" max="@Model.Questions.Count" class="form-control" />
+                        <input asp-for="QuestionAmount" min="1" class="form-control"/>
+                        <span class="text-danger" id="module-question-amount-insufficient-error" hidden>Aucune question n'existe pour ce module.</span>
                         <span asp-validation-for="QuestionAmount" class="text-danger"></span>
                     </div>
                     <div class="form-group">

--- a/TestGenerator.Web/wwwroot/js/site.js
+++ b/TestGenerator.Web/wwwroot/js/site.js
@@ -54,4 +54,23 @@ $(function () {
         $('.rdb').prop('checked', false);
         $(this).prop('checked', true);
     });
+
+
+    // Ajax call used to set the QuestionAmount field's max value in exam creation page.
+    $("#examCreationModuleSelect").change(function () {
+        var selectedModuleId = $(this).val();
+
+        if (selectedModuleId !== "") {
+            jQuery.get("/Exams/GetModuleQuestionsAmount?moduleId=" + selectedModuleId).done((res) => {
+                // Sets the input's max data and value
+                if (res.data > 0) {
+                    $("#QuestionAmount").prop('readonly', false).prop("max", res.data).val(1);
+                    $("#module-question-amount-insufficient-error").prop("hidden", true);
+                } else {
+                    $("#QuestionAmount").prop('readonly', true).val(0);
+                    $("#module-question-amount-insufficient-error").prop("hidden", false);
+                }
+            });
+        }
+    });
 });


### PR DESCRIPTION
Côté client, lors d'un changement de sélection sur la dropdown de choix d'un module, une requête AJAX est effectuée sur le controlleur, qui renvoie sous format JSON le nombre de questions d'un module. Cette valeur est ensuite utilisée pour déterminer la valeur maximale de l'input du nombre de questions d'un examen.